### PR TITLE
Validate config file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,9 +28,10 @@ class doas (
   String $mode       = '0555',
 ) {
   concat { $configfile:
-    owner => $owner,
-    group => $group,
-    mode  => $mode,
+    owner        => $owner,
+    group        => $group,
+    mode         => $mode,
+    validate_cmd => '/usr/bin/doas -C %',
   }
 
   concat::fragment { 'doas header':


### PR DESCRIPTION
Parse and check configuation such that the file is deployed if and only
if it is valid, i.e. invalid configurations (for example due to typoes
in any of the weakly types class parameters) will cause puppet to fail
instead of shipping a file that is known to produce doas(1) errors.

See https://man.openbsd.org/doas.1#C
