### PR TITLE
Sane default file permissions

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -75,7 +75,7 @@ Data type: `String`
 
 mode of $configfile
 
-Default value: `'0555'`
+Default value: `'0600'`
 
 ## Defined types
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,7 @@ class doas (
   Hash   $entries    = {},
   String $owner      = 'root',
   String $group      = 'wheel',
-  String $mode       = '0555',
+  String $mode       = '0600',
 ) {
   concat { $configfile:
     owner        => $owner,

--- a/spec/classes/doas_spec.rb
+++ b/spec/classes/doas_spec.rb
@@ -11,7 +11,7 @@ describe 'doas' do
         is_expected.to contain_concat('/etc/doas.conf')
           .with_owner('root')
           .with_group('wheel')
-          .with_mode('0555')
+          .with_mode('0600')
       }
       it {
         is_expected.to contain_concat__fragment('doas header')


### PR DESCRIPTION
doas.conf(5) is not an executable format, so `a+x` makes no sense.
It contains privileged commands/information by design, so `o+r` is questionable.

Use `u=rw,g=,o=` to match OpenBSD's /etc/examples/doas.conf suggestion.
