### PR TITLE
metadata: add OpenBSD 6.3 and 6.2 as supported for FacterDB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+---
+name: CI
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request: {}
+  push:
+    branches:
+      - main
+      - master
+
+concurrency:
+  group: ${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  puppet:
+    name: Puppet
+    uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v3


### PR DESCRIPTION
FacterDB does only support OpenBSD 6.3 and 6.2 if we remove these, no tests are running. So we keep these for now.